### PR TITLE
Link payment stub setup from React dev guide

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -33,3 +33,4 @@ parts:
     - file: react-example/swen90007-react-example-primer-milestone-1
     - file: react-example/swen90007-react-example-primer-milestone-2
     - file: react-example/swen90007-react-example-primer-milestone-3
+    - file: react-example/swen90007-react-example-primer-payment-stub

--- a/react-example/swen90007-react-example-primer-payment-stub.md
+++ b/react-example/swen90007-react-example-primer-payment-stub.md
@@ -1,0 +1,28 @@
+# Payment Stub
+
+Your project also integrates with the **payment stub** - a stateless stand-in for a
+3rd-party payment provider, published as a pre-built Docker image. Setup is identical to
+the JSP track: follow [Step 10: Set Up the Payment Stub](../setup_dev/10_payment_stub.md)
+for authenticating to GHCR (if needed), pulling and running the image (standalone or as a
+service in your `docker-compose.yml`), the `/quote` and `/payments` endpoints, the
+available configuration, and a Java client you can adapt for your API tier.
+
+```{note}
+You'll need Docker for this, set up in [Milestone 1: Deployment](swen90007-react-example-primer-milestone-1.md).
+Otherwise this can be done at any point - it doesn't depend on the other milestones.
+```
+
+:::{admonition} React-specific notes
+:class: tip
+- **Call it from your API, not the browser.** The React SPA talks to your Servlet API; the
+  Servlet API talks to the payment stub. Calling the stub directly from the browser would
+  expose the `SHARED_SECRET` (if you set one) and put a third-party dependency directly in
+  the client.
+- **The UI needs a pending state.** Every stub response takes 3-8 seconds by design. Disable
+  the submit control and show a spinner while the request is in flight, using the same
+  Hooks-based async patterns covered in
+  [Milestone 2: Core functionality](swen90007-react-example-primer-milestone-2.md).
+- **Give `REJECTED` and a 5xx different UX.** A `REJECTED` response is a clean decline -
+  show it as a normal validation-style message. A 5xx is a transient failure - show it as a
+  retryable error, not a declined payment.
+:::

--- a/react-example/swen90007-react-example-primer.md
+++ b/react-example/swen90007-react-example-primer.md
@@ -99,6 +99,14 @@ Implementing this stack will be a complicated undertaking. In an effort to manag
 - full-duplex communication with Websockets
 - some additional integrations
 
+#### Payment Stub
+
+- integrating with the payment stub, a stand-in for a 3rd-party payment provider, from your
+  API and UI
+
+This one sits outside the milestone sequence - once Docker is set up in *Milestone 1:
+Deployment* you can do it at any point.
+
 :::{admonition} Skipping milestones
 :class: caution
 Each milestone builds upon the implementation contributed by previous milestones. You should plan to complete each milestone in order; however, you may wish to skip early milestones if you're confident in your React, JavaEE or integration abilities. If you do skip early milestones, checkout the source code contributed by the previous milestone - for example, if you plan to start from *Milestone 1: Deployment* checkout the code from *Milestone 0: Hello world*. Note that *Milestone -1: Tools* will take you through installing critical dependencies such as a compatible Java JDK and Node.js runtime, be sure to confirm your local development environment is properly set up before proceeding with any of the other milestones.

--- a/setup_dev/10_payment_stub.md
+++ b/setup_dev/10_payment_stub.md
@@ -166,6 +166,94 @@ fail:
 docker run -p 8080:8080 -e FAILURE_RATE=1.0 ghcr.io/swen90007-2026/payment-stub:latest
 ```
 
+## Calling the Payment Stub from Java
+
+`java.net.http.HttpClient` ships with Java 17, so no new HTTP dependency is required. For
+JSON, use the same Jackson coordinates as the rest of the project (see [Milestone 2 of the
+React primer](../react-example/swen90007-react-example-primer-milestone-2.md) for where
+`ObjectMapper` comes from):
+
+```xml
+<properties>
+    <jackson.version>2.14.2</jackson.version>
+</properties>
+
+<dependencies>
+    <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+    </dependency>
+</dependencies>
+```
+
+A minimal gateway wrapping the two endpoints:
+
+```java
+public class PaymentStubGateway {
+
+    private final HttpClient client = HttpClient.newHttpClient();
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final URI baseUri; // e.g. http://payment-stub:8080, from config
+
+    public PaymentStubGateway(URI baseUri) {
+        this.baseUri = baseUri;
+    }
+
+    public PaymentResponse quote(BigDecimal amount, String attendeeRef) throws IOException, InterruptedException {
+        return post("/quote", Map.of("amount", amount, "attendeeRef", attendeeRef));
+    }
+
+    public PaymentResponse pay(BigDecimal amount, String bookingRef) throws IOException, InterruptedException {
+        return post("/payments", Map.of("amount", amount, "bookingRef", bookingRef));
+    }
+
+    private PaymentResponse post(String path, Object body) throws IOException, InterruptedException {
+        var request = HttpRequest.newBuilder(baseUri.resolve(path))
+                .header("Content-Type", "application/json")
+                .timeout(Duration.ofSeconds(15)) // comfortably above LATENCY_MAX_MS (default 8s)
+                .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body)))
+                .build();
+
+        var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() >= 500) {
+            // transient infrastructure failure - distinct from a REJECTED decision, handle separately
+            throw new PaymentGatewayUnavailableException(response.body());
+        }
+
+        return mapper.readValue(response.body(), PaymentResponse.class);
+    }
+}
+```
+
+```{note}
+Set the request timeout well above `LATENCY_MAX_MS` (default `8000`ms) - e.g. 15 seconds.
+The default `HttpClient` timeout, or any short timeout you set yourself, will fail against a
+perfectly healthy stub simply because every response is deliberately slow.
+```
+
+The response needs handling on two, distinct axes:
+
+- **A `200` with `"status": "REJECTED"`** is a clean business decision the stub returns on
+  purpose (amount above `DECLINE_THRESHOLD`) - surface it to the user as a declined payment.
+- **A 5xx** (`FAILURE_HTTP_STATUS`, default `503`, with a `FAILURE_CODE` in the body) is a
+  transient failure the stub injects at `FAILURE_RATE` - treat it like any other unavailable
+  upstream (retry, or fail the operation with a "try again" message), not as a decline.
+- **A `401`** means `SHARED_SECRET` is set on the stub but your request did not send a
+  matching `X-Payment-Secret` header.
+
+For the base URL, read `http://localhost:8080` (running the stub with `docker run` on your
+machine) or `http://payment-stub:8080` (running it as a Compose service, per the tip above)
+from configuration rather than hardcoding it, so local and deployed environments differ only
+by config.
+
+```{tip}
+Put this behind a small interface (e.g. `PaymentGateway`) and inject it into your service
+layer, rather than calling `HttpClient` directly from a servlet. It keeps the slow, flaky
+external call out of your request-handling code and makes it trivial to stub out in tests.
+```
+
 ## Observability (optional)
 
 The stub is instrumented with OpenTelemetry (traces + metrics), but export is **off by


### PR DESCRIPTION
## Summary
- Add a short pointer page under `react-example/` linking to `setup_dev/10_payment_stub.md`, with React-specific guidance (call it from the API tier not the browser, pending UI state for the 3-8s latency, and distinct UX for `REJECTED` vs a transient 5xx).
- Register the new page in `_toc.yml` (last chapter of *React Project Development Setup*) and mention it in the primer overview's milestone list.
- Add a "Calling the Payment Stub from Java" section to `setup_dev/10_payment_stub.md` (the canonical page, shared by both tracks) covering `java.net.http.HttpClient` + Jackson, timeouts above `LATENCY_MAX_MS`, and handling `REJECTED`/5xx/`401` separately.

## Test plan
- [x] Verified all new/edited relative markdown links resolve to existing files
- [x] Verified `_toc.yml` structure/indentation matches existing entries
- [ ] Build with `jupyter-book build .` and check the sidebar/navigation (jupyter-book wasn't available in this environment to run directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)